### PR TITLE
Fix/장바구니추가후 장바구니페이지에서 바로나오도록 수정

### DIFF
--- a/src/hooks/useProductQuery.tsx
+++ b/src/hooks/useProductQuery.tsx
@@ -5,12 +5,14 @@ import { changeProductState } from '../utils/fireStore/userInteract';
 import { Product } from '../static/const/type';
 import { useRecoilValue } from 'recoil';
 import { currentPushedLike } from '../atom/currentPushedLike';
+import { useNavigate } from 'react-router-dom';
 
 export const ALL_PRODUCT_QUERY_KEY = 'getAllProduct';
 
 const useProductQuery = () => {
   const queryClient = useQueryClient();
   const isPushed = useRecoilValue(currentPushedLike);
+  const navi = useNavigate();
 
   const { isLoading, isFetching, isError, data, error } = useQuery({
     queryKey: [ALL_PRODUCT_QUERY_KEY],
@@ -29,11 +31,9 @@ const useProductQuery = () => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [ALL_PRODUCT_QUERY_KEY] });
-    },
-   
+      navi('/mypage/basket');
+    }
   });
-
-  
 
   const updateProductMutation = useMutation({
     mutationFn: changeProductState,

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -79,7 +79,6 @@ const ProductDetailPage = (props: Props) => {
         setInBasket(true);
       } else {
         updateBasketMutation.mutate({ uid: currentUser?.uid, pid: detailData.id, mode: 'addedProducts' });
-        navi('/mypage/basket');
         setInBasket(true);
       }
     } else navi('/login');


### PR DESCRIPTION
장바구니 추가버튼 클릭 함수에서 updateBasketMutation 함수의 뮤테이트를 실행시키고 navi를 하던 것에서 
 updateBasketMutation 함수 뮤테이트의 onSuccess 자체에서 navi하도록 변경.

close #43 